### PR TITLE
feat: add filter input with debounce and reactive filtering

### DIFF
--- a/src/app/periodic-table/periodic-table.html
+++ b/src/app/periodic-table/periodic-table.html
@@ -1,6 +1,12 @@
 <div class="bg-white p-6 rounded-xl shadow-xl w-full max-w-2xl mx-auto">
     <h2 class="text-2xl font-bold text-center text-indigo-700 mb-4">Periodic Table</h2>
-  
+    <input
+  type="text"
+  placeholder="Filter elements..."
+  class="w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-4"
+  (input)="onFilterInput($event)"
+/>
+
     <ng-container *ngIf="!loading(); else loadingTemplate">
         <table mat-table [dataSource]="elements() ?? []" class="mat-elevation-z2 w-full table-auto border-separate">
   


### PR DESCRIPTION
This feature introduces a filtering input that allows users to search for elements in the periodic table. The filter includes a 2-second debounce and integrates with the reactive state. The table updates automatically based on the query, and edited elements are immediately re-evaluated against the filter.